### PR TITLE
Fix Socket is not connected error

### DIFF
--- a/Sources/Redis.swift
+++ b/Sources/Redis.swift
@@ -5,6 +5,7 @@ public final class Redis: Commands {
 	public var conn: TCPConnection
 
 	public init(_ host: String, _ port: Int) throws {
-        conn = try TCPConnection(host: host, port: port)
+        	conn = try TCPConnection(host: host, port: port)
+        	try conn.open()
 	}
 }


### PR DESCRIPTION
Add conn.open() method while initializing Redis() object
